### PR TITLE
use grunt-react instead of exec

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,10 +7,19 @@ module.exports = function(grunt) {
         globals: {}
       }
     },
+    react: {
+      files: {
+        expand: true,
+        cwd: 'client/scripts',
+        src: ['**/*.js'],
+        dest: 'parse/public/scripts',
+        ext: '.js'
+      }
+    },
     watch: {
       parse: {
         files: ['Gruntfile.js', 'client/**/*','server/**/*'],
-        tasks: ['parse-copy']
+        tasks: ['react','parse-copy']
       }
     },
     copy: {
@@ -18,7 +27,7 @@ module.exports = function(grunt) {
         expand: true,
         cwd: 'client',
         dest: 'parse/public/',
-        src: '**/*'
+        src: ['**/*.css', '**/*.html']
       },
       server: {
         expand: true,
@@ -65,7 +74,7 @@ module.exports = function(grunt) {
       }
     },
     exec: {
-      serve: 'jsx --watch client/scripts/ parse/public/build & cd parse/ && parsedev &',
+      serve: 'cd parse/ && parsedev &',
       deploy: 'cd parse/ && parse deploy'
     }
   });
@@ -75,9 +84,10 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-exec');
+  grunt.loadNpmTasks('grunt-react');
 
 
   grunt.registerTask('default', ['jshint']);
   grunt.registerTask('parse-copy',['copy:client','copy:vendor', 'copy:server']);
-  grunt.registerTask('serve', ['clean:parse','parse-copy', 'exec:serve', 'watch:parse']);
+  grunt.registerTask('serve', ['clean:parse','parse-copy', 'react', 'exec:serve', 'watch:parse']);
 };

--- a/client/index.html
+++ b/client/index.html
@@ -33,8 +33,8 @@
     var Link = ReactRouter.Link;
     var RouteHandler = ReactRouter.RouteHandler;
   </script>
-  <script src="build/user.js"></script>
-  <script src="build/signup.js"></script>
+  <script src="scripts/user.js"></script>
+  <script src="scripts/signup.js"></script>
 </head>
 <body>
   <div class="container">
@@ -58,7 +58,7 @@
     </div>
   </div>
 </body>
-  <script src="build/app.js"></script>
+  <script src="scripts/app.js"></script>
 </html>
 <!--
 <html>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-exec": "^0.4.6",
+    "grunt-react": "^0.12.2",
     "parse-develop": "0.0.55"
   },
   "dependencies": {


### PR DESCRIPTION
Assumes all .js files are jsx and need to be compiled.
Known issue: After running grunt serve and then modifying a file, it will log the following warnings:

``` bash
Done, without errors.
Completed in 0.690s at Mon Jul 06 2015 19:57:50 GMT-0700 (PDT) - Waiting...
>> Restaring script because /Users/valdrinkoshi/Development/ceek/parse/public/scripts/app.js changed
>> Restaring script because /Users/valdrinkoshi/Development/ceek/parse/public/scripts/signup.js changed
>> Restaring script because /Users/valdrinkoshi/Development/ceek/parse/public/scripts/user.js changed
>> Forever detected script exited with code null
>> Forever restarting script for 1 time
[7414] Running on http://localhost:3000/
```

This will be solved in a separate PR, as it is not blocking (updates are available)
